### PR TITLE
updating dependencies on firebase_auth and flutter_facebook_login

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ build/
 ios/.generated/
 packages
 pubspec.lock
+
+example/ios/Flutter/flutter_export_environment.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [1.0.8] - 02/10/2019
+* update dependencies
+
 ## [1.0.7] - 21/5/2019
 * fixed padding
 

--- a/lib/login_view.dart
+++ b/lib/login_view.dart
@@ -51,7 +51,8 @@ class _LoginViewState extends State<LoginView> {
         try {
           AuthCredential credential = GoogleAuthProvider.getCredential(
               idToken: googleAuth.idToken, accessToken: googleAuth.accessToken);
-          FirebaseUser user = await _auth.signInWithCredential(credential);
+          AuthResult authResult = await _auth.signInWithCredential(credential);
+          FirebaseUser user = authResult.user;
           print(user);
         } catch (e) {
           showErrorDialog(context, e.details);
@@ -62,12 +63,13 @@ class _LoginViewState extends State<LoginView> {
 
   _handleFacebookSignin() async {
     FacebookLoginResult result =
-        await facebookLogin.logInWithReadPermissions(['email']);
+        await facebookLogin.logIn(['email']);
     if (result.accessToken != null) {
       try {
         AuthCredential credential = FacebookAuthProvider.getCredential(
             accessToken: result.accessToken.token);
-        FirebaseUser user = await _auth.signInWithCredential(credential);
+        AuthResult authResult = await _auth.signInWithCredential(credential);
+        FirebaseUser user = authResult.user;
         print(user);
       } catch (e) {
         showErrorDialog(context, e.details);

--- a/lib/password_view.dart
+++ b/lib/password_view.dart
@@ -101,10 +101,12 @@ class _PasswordViewState extends State<PasswordView> {
 
   _connexion(BuildContext context) async {
     FirebaseAuth _auth = FirebaseAuth.instance;
+    AuthResult authResult;
     FirebaseUser user;
     try {
-      user = await _auth.signInWithEmailAndPassword(
+      authResult = await _auth.signInWithEmailAndPassword(
           email: _controllerEmail.text, password: _controllerPassword.text);
+      user = authResult.user;
       print(user);
     } catch (exception) {
       //TODO improve errors catching

--- a/lib/sign_up_view.dart
+++ b/lib/sign_up_view.dart
@@ -133,10 +133,11 @@ class _SignUpViewState extends State<SignUpView> {
 
     FirebaseAuth _auth = FirebaseAuth.instance;
     try {
-      FirebaseUser user = await _auth.createUserWithEmailAndPassword(
+      AuthResult authResult = await _auth.createUserWithEmailAndPassword(
         email: _controllerEmail.text,
         password: _controllerPassword.text,
       );
+      FirebaseUser user = authResult.user;
       try {
         var userUpdateInfo = new UserUpdateInfo();
         userUpdateInfo.displayName = _controllerDisplayName.text;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: firebase_ui
 description: Firebase auth UI, dart package to mimic the firebaseUI(Google,Facebook,Twitter,Email supported)
-version: 1.0.7
+version: 1.0.8
 author: Nicholas Bowler <crucifixx25@gmail.com>
 homepage: https://github.com/Maliffic/firebase_ui
 
@@ -13,10 +13,10 @@ dependencies:
 
   flutter_twitter: ^1.1.2
 
-  firebase_auth: ^0.11.1+12
+  firebase_auth: ^0.14.0+5
   
   google_sign_in: ^4.0.4
-  flutter_facebook_login: ^2.0.1
+  flutter_facebook_login: ^3.0.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
iOS 13 breaks flutter_facebook_login 2.0.1, this PR is updating dependencies to 3.0.0 which uses the v5 of the FB SDK.
Fixes #18 